### PR TITLE
Add comprehensive plan for Anki card generation links feature

### DIFF
--- a/ANKI_USAGE.md
+++ b/ANKI_USAGE.md
@@ -1,0 +1,215 @@
+# Anki Card Generation Feature
+
+## Overview
+
+The Selkouutiset Archive now includes built-in Anki flashcard generation! Create bilingual flashcards directly from any article to enhance your Finnish language learning.
+
+## What is Anki?
+
+[Anki](https://apps.ankiweb.net/) is a powerful, free, open-source spaced repetition flashcard program that helps you memorize information efficiently. It's perfect for language learning.
+
+## How to Use
+
+### 1. Navigate to Any Article
+
+Browse to any article page on the Selkouutiset Archive. You'll see language selectors and Anki generation links at the top:
+
+```
+Languages: [fi] [en]
+Generate Anki Cards: [sentence] [paragraph] [section]
+```
+
+### 2. Choose Your Granularity Level
+
+Click on one of the three options based on how you want to study:
+
+- **[sentence]** - Creates one flashcard for each sentence
+  - Best for: Beginners, detailed study, grammar practice
+  - Card count: Highest (50-200+ cards per article)
+  - Example: "Presidentti tapasi pääministerin." ↔ "The president met the prime minister."
+
+- **[paragraph]** - Creates one flashcard for each paragraph
+  - Best for: Intermediate learners, contextual understanding
+  - Card count: Medium (10-30 cards per article)
+  - Example: Full paragraph in Finnish ↔ Full paragraph in English
+
+- **[section]** - Creates one flashcard for each section/heading
+  - Best for: Advanced learners, topic comprehension
+  - Card count: Lowest (3-10 cards per article)
+  - Example: Entire section under a heading in Finnish ↔ Entire section in English
+
+### 3. Download the File
+
+After clicking a granularity level:
+1. The system fetches both language versions of the article
+2. Parses and pairs the content
+3. Generates flashcards
+4. Downloads a `.txt` file (e.g., `anki_article_title_sentence_2026-01-18.txt`)
+
+### 4. Import into Anki
+
+#### If You Don't Have Anki Yet:
+1. Download Anki from [https://apps.ankiweb.net/](https://apps.ankiweb.net/)
+2. Install it on your computer
+3. Open Anki and create a new deck (e.g., "Selkouutiset - Finnish Learning")
+
+#### Import the Generated File:
+1. Open Anki
+2. Click **File → Import**
+3. Select the downloaded `.txt` file
+4. In the import dialog:
+   - **Type**: Basic
+   - **Deck**: Choose or create a deck (e.g., "Selkouutiset")
+   - **Fields separated by**: Tab
+   - **Allow HTML in fields**: ✓ (checked)
+   - **Field 1**: Front
+   - **Field 2**: Back
+   - **Field 3**: Tags
+5. Click **Import**
+
+### 5. Study!
+
+Your cards are now in Anki. Click on your deck and start studying!
+
+## Card Format
+
+Each generated card includes:
+- **Front**: Finnish text (from the original article)
+- **Back**: English translation
+- **Tags**: `selkouutiset`, language pair (e.g., `fi-en`), granularity level, and date
+
+## Tips for Effective Learning
+
+### For Sentence-Level Cards:
+- Perfect for drilling specific vocabulary and grammar patterns
+- Can be overwhelming for longer articles - consider generating cards for specific articles you want to study deeply
+- Great for understanding Finnish sentence structure
+
+### For Paragraph-Level Cards:
+- Balances detail with manageability
+- Helps you understand how sentences flow together
+- Recommended for most learners
+
+### For Section-Level Cards:
+- Best for reviewing overall article comprehension
+- Useful for advanced learners who want to ensure they understand main ideas
+- Can be combined with sentence/paragraph cards for the same article
+
+### General Tips:
+1. **Don't generate too many cards at once** - Start with a few articles you find interesting
+2. **Be consistent** - Study your cards daily for best results (Anki will remind you)
+3. **Suspend difficult cards** - If a card is too hard, suspend it in Anki and come back later
+4. **Add custom notes** - In Anki, you can edit cards to add pronunciation notes, mnemonics, etc.
+5. **Mix granularity levels** - Try combining sentence and paragraph cards for the same article for different perspectives
+
+## Technical Details
+
+### What Languages Are Supported?
+- Currently supports Finnish ↔ English pairs
+- Cards always show Finnish on the front and English on the back (regardless of which language version of the article you're viewing)
+
+### How Are Sentences/Paragraphs Paired?
+The system:
+1. Fetches both the Finnish and English versions of the article
+2. Splits the content based on the selected granularity
+3. Pairs matching segments by position (e.g., 1st Finnish paragraph with 1st English paragraph)
+4. Creates flashcards from these pairs
+
+**Note**: If the Finnish and English versions have different numbers of sentences/paragraphs, only matching pairs are included. The system uses the minimum count to avoid misalignment.
+
+### What if There's No Translation?
+If an article doesn't have a translation in the other language, you'll see an error message. Anki cards can only be generated for articles that exist in both Finnish and English.
+
+### File Format
+The generated `.txt` files use Tab-Separated Values (TSV) format with Anki-specific headers:
+```
+#separator:tab
+#html:false
+#tags column:3
+# Source: Article Title
+# URL: https://example.org/article
+
+Finnish text<tab>English text<tab>tags
+...
+```
+
+This format is specifically designed for easy import into Anki.
+
+## Troubleshooting
+
+### "No cards generated" Error
+**Cause**: The article might not have a translation, or the content structure is incompatible.
+
+**Solution**:
+- Check if both [fi] and [en] language links are available
+- Try a different article
+- Report the issue if you believe it should work
+
+### Cards Don't Align Properly
+**Cause**: The Finnish and English versions might have different paragraph/sentence structures.
+
+**Solution**:
+- Try a different granularity level
+- Manually review and edit cards in Anki after import
+- Some articles translate more freely and won't align perfectly
+
+### Import Fails in Anki
+**Cause**: Incorrect import settings.
+
+**Solution**:
+- Ensure "Fields separated by: Tab" is selected
+- Enable "Allow HTML in fields"
+- Make sure you're importing as "Basic" type
+
+### JavaScript Not Working
+**Cause**: Browser blocking scripts, or JavaScript disabled.
+
+**Solution**:
+- Enable JavaScript in your browser
+- Try a different browser
+- Check browser console for errors (F12 → Console)
+
+## Example Workflow
+
+Here's a complete example of using the feature:
+
+1. **Choose an article**: Browse to an interesting article, e.g., "Suomi voitti jääkiekkoa" (Finland won at hockey)
+
+2. **Select granularity**: Click **[paragraph]** for a balanced approach
+
+3. **Wait for download**: After a few seconds, `anki_Suomi_voitti_jääkiekkoa_paragraph_2026-01-18.txt` downloads
+
+4. **Import to Anki**:
+   - Open Anki
+   - File → Import
+   - Select the downloaded file
+   - Set separator to Tab
+   - Import into "Selkouutiset" deck
+
+5. **Study**: Start reviewing! Anki will show you Finnish paragraphs, and you try to recall the English meaning before revealing the back of the card.
+
+6. **Repeat**: Generate cards from other articles and build up your deck over time!
+
+## Advanced: Reverse Cards (English → Finnish)
+
+By default, cards show Finnish on the front. If you want to study the reverse direction (English → Finnish):
+
+1. In Anki, go to **Tools → Manage Note Types**
+2. Select your note type (e.g., "Basic")
+3. Click **Options** → **Add Card Type**
+4. Create a reversed card template
+
+Or simply:
+1. Import the cards as usual
+2. When studying, mentally practice both directions
+
+## Credits
+
+This feature generates flashcards from the excellent [Selkouutiset](https://yle.fi/selkouutiset) news articles, which are published by YLE (Finnish Broadcasting Company) and provide simplified Finnish news with English translations.
+
+## Feedback
+
+If you encounter issues or have suggestions for improving the Anki generation feature, please report them at:
+https://github.com/hiAndrewQuinn/selkouutiset-archive/issues
+
+Happy learning! 🇫🇮📚

--- a/PLAN_ANKI_GENERATION_LINKS.md
+++ b/PLAN_ANKI_GENERATION_LINKS.md
@@ -1,0 +1,365 @@
+# Plan: Add Anki Card Generation Links
+
+## Overview
+Add hyperlinks next to the language selectors [fi] and [en] that allow users to generate Anki flashcards from article content at three different granularity levels:
+- Sentence level
+- Paragraph level
+- Whole sections level
+
+## Current State
+
+### Language Selector Location
+- **File**: `themes/selkoarchive/layouts/_default/single.html`
+- **Current Structure**:
+  ```html
+  <aside>
+  Languages:
+  {{ range .AllTranslations }}
+    {{ $langName := or .Language.LanguageName .Language.Lang }}
+    {{ $langCode := or .Language.LanguageCode .Language.Lang }}
+    <a href="{{ .RelPermalink }}" hreflang="{{ $langCode }}">[{{ $langName }}]</a>
+  {{ end }}
+  </aside>
+  ```
+
+### Styling
+- Uses classless CSS design
+- Link styling defined in `themes/selkoarchive/assets/css/main.css`
+- Copper color (#a8763eff) with dotted underline
+- Hover state with light yellow background
+
+## Proposed Implementation
+
+### Phase 1: UI Changes
+
+#### 1.1 Template Modification
+**File**: `themes/selkoarchive/layouts/_default/single.html`
+
+Add Anki generation links after the language selectors:
+
+```html
+<aside>
+Languages:
+{{ range .AllTranslations }}
+  {{ $langName := or .Language.LanguageName .Language.Lang }}
+  {{ $langCode := or .Language.LanguageCode .Language.Lang }}
+  <a href="{{ .RelPermalink }}" hreflang="{{ $langCode }}">[{{ $langName }}]</a>
+{{ end }}
+<br>
+Generate Anki Cards:
+<a href="/anki/generate?page={{ .RelPermalink }}&level=sentence">[sentence]</a>
+<a href="/anki/generate?page={{ .RelPermalink }}&level=paragraph">[paragraph]</a>
+<a href="/anki/generate?page={{ .RelPermalink }}&level=section">[section]</a>
+</aside>
+```
+
+**Alternative Layout** (inline, more compact):
+```html
+<aside>
+Languages:
+{{ range .AllTranslations }}
+  {{ $langName := or .Language.LanguageName .Language.Lang }}
+  {{ $langCode := or .Language.LanguageCode .Language.Lang }}
+  <a href="{{ .RelPermalink }}" hreflang="{{ $langCode }}">[{{ $langName }}]</a>
+{{ end }}
+| Anki:
+<a href="/anki/generate?page={{ .RelPermalink }}&level=sentence">[sentence]</a>
+<a href="/anki/generate?page={{ .RelPermalink }}&level=paragraph">[paragraph]</a>
+<a href="/anki/generate?page={{ .RelPermalink }}&level=section">[section]</a>
+</aside>
+```
+
+#### 1.2 CSS Considerations
+- Links will inherit existing link styling
+- Consider adding a specific class if different styling is desired
+- Ensure adequate spacing between language selectors and Anki links
+
+### Phase 2: Backend Implementation
+
+#### 2.1 Anki Generation Approach
+
+**Option A: External Service Integration**
+- Link to an external Anki card generation service
+- Pass article URL and granularity level as parameters
+- Pros: No backend development needed
+- Cons: Dependency on external service, potential privacy concerns
+
+**Option B: Static Site Generator (Hugo) Partial**
+- Create a Hugo partial that generates Anki-compatible files at build time
+- Use Hugo's content processing capabilities
+- Pros: Works with static site, no server needed
+- Cons: Limited to pre-generated cards, no dynamic generation
+
+**Option C: Server-Side Script/API**
+- Implement a lightweight API endpoint (e.g., Python Flask, Go, Node.js)
+- Process article content on-demand
+- Generate and return Anki deck files (.apkg)
+- Pros: Full control, dynamic generation
+- Cons: Requires server infrastructure, adds complexity
+
+**Option D: Client-Side JavaScript**
+- Use JavaScript to parse article content in the browser
+- Generate Anki cards using libraries like genanki-js or ankiconnect
+- Download as .apkg or send to AnkiConnect
+- Pros: No server needed, works with static site
+- Cons: Processing in browser, limited by client capabilities
+
+**Recommended Approach**: Option C (Server-Side Script) or Option D (Client-Side JavaScript)
+
+#### 2.2 Content Parsing Requirements
+
+**Sentence Level**:
+- Parse article content and split into individual sentences
+- Use language-aware sentence tokenization (different rules for Finnish vs English)
+- Each flashcard: Front = Finnish sentence, Back = English translation (or vice versa)
+
+**Paragraph Level**:
+- Split content into paragraphs
+- Each flashcard: Front = Finnish paragraph, Back = English paragraph
+- Consider chunking very long paragraphs
+
+**Section Level**:
+- Identify sections (using HTML headings: h2, h3, etc.)
+- Each flashcard: Front = Finnish section, Back = English section
+- May need to limit to smaller sections to keep cards manageable
+
+#### 2.3 Bilingual Content Handling
+
+Since the site has both Finnish and English versions:
+- Option 1: Always create bilingual cards (FI front / EN back)
+- Option 2: Let user choose which direction (FI→EN or EN→FI)
+- Option 3: Create cloze deletion cards instead of translation cards
+
+#### 2.4 Anki Card Format
+
+**Basic Structure** (using Anki's .apkg format):
+- Deck name: "Selkouutiset - [Article Title] - [Level]"
+- Model: Basic or Basic (and reversed card)
+- Fields: Front, Back, Source URL, Date
+- Tags: selkouutiset, [language], [level], [date]
+
+**Metadata to Include**:
+- Article title
+- Publication date
+- Source URL
+- Language pair
+- Granularity level
+
+### Phase 3: Technical Implementation Details
+
+#### 3.1 If Using Server-Side API
+
+**Endpoint Structure**:
+```
+POST /anki/generate
+Content-Type: application/json
+
+{
+  "pageUrl": "https://example.org/articles/...",
+  "level": "sentence|paragraph|section",
+  "sourceLanguage": "fi",
+  "targetLanguage": "en"
+}
+
+Response:
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="selkouutiset-deck.apkg"
+[Binary .apkg file]
+```
+
+**Technology Stack Options**:
+- Python + Flask + genanki library
+- Node.js + Express + anki-apkg-export
+- Go + net/http + custom Anki format implementation
+
+**Repository Structure**:
+```
+/anki-generator/
+  ├── src/
+  │   ├── parser.py/js      # Content parsing logic
+  │   ├── generator.py/js   # Anki deck generation
+  │   └── api.py/js         # API endpoint handlers
+  ├── requirements.txt / package.json
+  └── README.md
+```
+
+#### 3.2 If Using Client-Side JavaScript
+
+**Implementation**:
+- Add JavaScript to single.html or as a separate asset
+- Use libraries: marked.js (for parsing), anki-apkg-export (for generation)
+- Fetch bilingual content from both language versions
+- Process and generate deck in browser
+- Trigger download of .apkg file
+
+**Challenges**:
+- Need to fetch both language versions (CORS considerations)
+- Larger JavaScript bundle size
+- Processing time for large articles
+
+#### 3.3 Hugo Integration Considerations
+
+**If content is in submodule**:
+- Content lives in separate repository: https://github.com/hiAndrewQuinn/selkouutiset-scrape-cleaned
+- Need to ensure bilingual pairing is reliable
+- May need to match Finnish and English versions by filename convention
+
+**Content Access**:
+- Hugo provides `.Content` for rendered HTML
+- May need access to raw markdown for better parsing
+- Use `.RawContent` or `.Plain` for text-only content
+
+### Phase 4: User Experience Flow
+
+1. User reads an article in their preferred language (fi or en)
+2. User decides they want to create Anki flashcards
+3. User clicks one of the three granularity options: [sentence] / [paragraph] / [section]
+4. System:
+   - Fetches both language versions of the article
+   - Parses content based on selected granularity
+   - Generates Anki deck with paired content
+   - Returns .apkg file for download
+5. User imports the .apkg file into their Anki application
+6. User studies the flashcards
+
+**Optional Enhancements**:
+- Preview mode: Show what cards will be generated before downloading
+- Customization: Let users select specific sentences/paragraphs to include
+- Card type selection: Translation cards vs. Cloze deletion
+- Integration with AnkiConnect: Directly add to Anki without file download
+
+### Phase 5: Testing Strategy
+
+#### 5.1 Unit Tests
+- Test sentence tokenization for Finnish and English
+- Test paragraph splitting
+- Test section identification
+- Test Anki deck generation
+
+#### 5.2 Integration Tests
+- Test full workflow: URL → parsed content → generated deck → valid .apkg
+- Test with various article lengths and structures
+- Test with special characters and Finnish-specific characters (ä, ö, å)
+
+#### 5.3 Manual Testing
+- Generate decks for sample articles
+- Import into Anki and verify cards display correctly
+- Test all three granularity levels
+- Test with both Finnish and English source pages
+
+### Phase 6: Documentation
+
+#### 6.1 User Documentation
+- Add section to README explaining the Anki generation feature
+- Include instructions for importing .apkg files into Anki
+- Explain the three granularity levels
+
+#### 6.2 Developer Documentation
+- Document the API endpoint (if applicable)
+- Explain the content parsing logic
+- Provide examples of the generated Anki deck structure
+
+## Open Questions
+
+1. **Hosting**: Where will the Anki generation service be hosted?
+   - GitHub Pages (static only, rules out server-side API)
+   - Netlify/Vercel (supports serverless functions)
+   - Self-hosted server
+   - Client-side only (no hosting needed)
+
+2. **Card Direction**: Which direction should translation cards go?
+   - Always FI → EN?
+   - Always EN → FI?
+   - User selectable?
+   - Generate reversible cards?
+
+3. **Content Alignment**: How to ensure Finnish and English content segments align properly?
+   - Rely on article structure (same number of paragraphs/sections)?
+   - Use paragraph-level matching heuristics?
+   - Manual curation needed?
+
+4. **Rate Limiting**: Should we limit how many decks users can generate?
+   - Prevent abuse if using server resources
+   - Or unlimited if client-side?
+
+5. **Anki Model**: Which Anki note type to use?
+   - Basic
+   - Basic (and reversed card)
+   - Cloze
+   - Custom model with additional fields?
+
+## Implementation Roadmap
+
+### Minimal Viable Product (MVP)
+1. Add UI links to single.html template
+2. Implement basic client-side JavaScript solution
+3. Support sentence-level cards only
+4. Generate FI → EN translation cards
+5. Download as .apkg file
+
+### Future Enhancements
+- Paragraph and section level support
+- Server-side API for better performance
+- Card customization options
+- AnkiConnect integration
+- Preview functionality
+- Custom styling/CSS for Anki links
+- Statistics: track which articles have generated decks
+
+## Alternative Approaches
+
+### Approach 1: Pre-generated Decks
+Instead of dynamic generation, pre-generate Anki decks for all articles at build time:
+- Add decks to git repository or separate storage
+- Links download pre-generated files
+- Pros: Simple, fast, works with static hosting
+- Cons: Large repository size, updates require rebuild
+
+### Approach 2: Bookmarklet
+Instead of inline links, provide a bookmarklet that users can drag to their browser:
+- Users click bookmarklet while on any article
+- JavaScript extracts content and generates deck
+- Pros: No template changes needed, works anywhere
+- Cons: Less discoverable, more steps for users
+
+### Approach 3: Browser Extension
+Create a dedicated browser extension:
+- Extension detects selkouutiset pages
+- Adds Anki generation button
+- Handles all logic in extension
+- Pros: Rich functionality, no site changes needed
+- Cons: Users must install extension, development overhead
+
+## Success Criteria
+
+- [ ] Links are visible and accessible on all article pages
+- [ ] Links follow the existing design language
+- [ ] Generated Anki decks import successfully into Anki
+- [ ] Cards display correctly with Finnish and English content
+- [ ] All three granularity levels work as expected
+- [ ] Content pairing is accurate (FI and EN segments match)
+- [ ] Performance is acceptable (< 5 seconds for deck generation)
+- [ ] Works on both desktop and mobile browsers
+- [ ] Documentation is clear and complete
+
+## Estimated Complexity
+
+- **UI Changes**: Low (1-2 hours)
+- **Client-side Implementation**: Medium (8-16 hours)
+- **Server-side Implementation**: Medium-High (16-24 hours)
+- **Testing & Refinement**: Medium (8-12 hours)
+- **Documentation**: Low (2-4 hours)
+
+**Total Estimate**: 19-58 hours depending on approach chosen
+
+## Recommendation
+
+**Recommended Path Forward**:
+1. Start with client-side JavaScript implementation for MVP
+2. Add UI links with basic styling
+3. Implement sentence-level generation first
+4. Test with representative articles
+5. Iterate based on user feedback
+6. Consider server-side migration if performance/features require it
+
+This approach minimizes infrastructure requirements while providing immediate value, and allows for future enhancement without major refactoring.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ popd
 ```
 
 That's all you need! Go to `http://localhost:1313` to see your website.
+
+## Features
+
+### 🎴 Anki Flashcard Generation
+
+The archive now includes built-in Anki flashcard generation! Create bilingual flashcards directly from any article to enhance your Finnish language learning.
+
+**Three granularity levels:**
+- **[sentence]** - One flashcard per sentence (best for beginners)
+- **[paragraph]** - One flashcard per paragraph (best for intermediate learners)
+- **[section]** - One flashcard per section (best for advanced learners)
+
+Simply click on any of these links when viewing an article, and a downloadable text file will be generated that you can import into Anki.
+
+📖 **[Read the complete Anki usage guide](ANKI_USAGE.md)** for detailed instructions on how to use this feature.

--- a/themes/selkoarchive/assets/css/main.css
+++ b/themes/selkoarchive/assets/css/main.css
@@ -183,6 +183,19 @@ tbody td:hover {
   color: var(--specsavers-green);
 }
 
+/* --- Aside Styling (Language & Anki Links) --- */
+aside {
+  margin: 1em 0;
+  padding: 0.75em;
+  background-color: var(--antiflash-white);
+  border-left: 3px solid var(--copper);
+  font-size: 0.9em;
+}
+
+aside a {
+  margin-right: 0.5em;
+}
+
 /* --- Mobile Compacting Rules --- */
 @media screen and (max-width: 767px) {
   /* Reduce base font size slightly to fit more text */

--- a/themes/selkoarchive/layouts/_default/single.html
+++ b/themes/selkoarchive/layouts/_default/single.html
@@ -7,7 +7,9 @@
     <a href="{{ .RelPermalink }}" hreflang="{{ $langCode }}">[{{ $langName }}]</a>
   {{ end }}
   <br>
-  Generate Anki Cards:
+  {{ $currentLang := or .Language.Lang "fi" }}
+  {{ $otherLang := cond (eq $currentLang "fi") "en" "fi" }}
+  Generate Anki Cards ({{ $currentLang }} → {{ $otherLang }}):
   <a href="#" onclick="generateAnkiCards('sentence'); return false;" title="Generate flashcards for each sentence">[sentence]</a>
   <a href="#" onclick="generateAnkiCards('paragraph'); return false;" title="Generate flashcards for each paragraph">[paragraph]</a>
   <a href="#" onclick="generateAnkiCards('section'); return false;" title="Generate flashcards for each section">[section]</a>

--- a/themes/selkoarchive/layouts/_default/single.html
+++ b/themes/selkoarchive/layouts/_default/single.html
@@ -6,8 +6,14 @@
     {{ $langCode := or .Language.LanguageCode .Language.Lang }}
     <a href="{{ .RelPermalink }}" hreflang="{{ $langCode }}">[{{ $langName }}]</a>
   {{ end }}
+  <br>
+  Generate Anki Cards:
+  <a href="#" onclick="generateAnkiCards('sentence'); return false;" title="Generate flashcards for each sentence">[sentence]</a>
+  <a href="#" onclick="generateAnkiCards('paragraph'); return false;" title="Generate flashcards for each paragraph">[paragraph]</a>
+  <a href="#" onclick="generateAnkiCards('section'); return false;" title="Generate flashcards for each section">[section]</a>
   </aside>
   <article class="prose">
     {{ .Content }}
   </article>
+  <script src="{{ "js/anki-generator.js" | relURL }}"></script>
 {{ end }}

--- a/themes/selkoarchive/static/js/anki-generator.js
+++ b/themes/selkoarchive/static/js/anki-generator.js
@@ -189,13 +189,16 @@ class AnkiGenerator {
     const currentParagraphs = this.splitIntoParagraphs(currentArticle);
     const translationParagraphs = this.splitIntoParagraphs(translationArticle);
 
+    console.log('\n═══════════════════════════════════════════════════════════');
+    console.log('🎴 ANKI SENTENCE CARD GENERATION - DETAILED LOG');
+    console.log('═══════════════════════════════════════════════════════════');
     console.log(`Found ${currentParagraphs.length} paragraphs in ${this.currentLang}, ${translationParagraphs.length} in ${this.otherLang}`);
 
     // Warn if paragraph counts are very different
     const paragraphRatio = Math.max(currentParagraphs.length, translationParagraphs.length) /
                           Math.min(currentParagraphs.length, translationParagraphs.length);
     if (paragraphRatio > 1.5) {
-      console.warn(`Warning: Paragraph count mismatch. This may indicate parsing issues or different article structures.`);
+      console.warn(`⚠️  WARNING: Paragraph count mismatch. This may indicate parsing issues or different article structures.`);
     }
 
     const cards = [];
@@ -208,13 +211,17 @@ class AnkiGenerator {
       const currentSentences = this.splitIntoSentences(currentParagraphs[i]);
       const translationSentences = this.splitIntoSentences(translationParagraphs[i]);
 
-      console.log(`Paragraph ${i + 1}: ${currentSentences.length} sentences in ${this.currentLang}, ${translationSentences.length} in ${this.otherLang}`);
+      console.log(`\n--- Paragraph ${i + 1} ---`);
+      console.log(`${this.currentLang} sentences (${currentSentences.length}):`);
+      currentSentences.forEach((s, idx) => console.log(`  [${idx + 1}] ${s.substring(0, 100)}${s.length > 100 ? '...' : ''}`));
+      console.log(`${this.otherLang} sentences (${translationSentences.length}):`);
+      translationSentences.forEach((s, idx) => console.log(`  [${idx + 1}] ${s.substring(0, 100)}${s.length > 100 ? '...' : ''}`));
 
       // Skip paragraphs with severe sentence count mismatches (likely parsing errors)
       const sentenceRatio = Math.max(currentSentences.length, translationSentences.length) /
                            Math.max(Math.min(currentSentences.length, translationSentences.length), 1);
       if (sentenceRatio > 2.5 && Math.abs(currentSentences.length - translationSentences.length) > 2) {
-        console.warn(`Skipping paragraph ${i + 1} due to severe sentence count mismatch (${currentSentences.length} vs ${translationSentences.length})`);
+        console.warn(`⚠️  SKIPPING paragraph ${i + 1} due to severe sentence count mismatch (${currentSentences.length} vs ${translationSentences.length})`);
         skippedParagraphs++;
         continue;
       }
@@ -222,19 +229,35 @@ class AnkiGenerator {
       // Pair sentences - use the minimum count to avoid misalignment
       const maxSentences = Math.min(currentSentences.length, translationSentences.length);
 
+      console.log(`\nPairing sentences (using ${maxSentences} pairs):`);
       for (let j = 0; j < maxSentences; j++) {
-        const front = this.currentLang === 'fi' ? currentSentences[j] : translationSentences[j];
-        const back = this.currentLang === 'fi' ? translationSentences[j] : currentSentences[j];
+        const fiSentence = this.currentLang === 'fi' ? currentSentences[j] : translationSentences[j];
+        const enSentence = this.currentLang === 'fi' ? translationSentences[j] : currentSentences[j];
 
-        if (front && back) {
-          cards.push({ front, back });
+        if (fiSentence && enSentence) {
+          console.log(`  Card ${cards.length + 1}:`);
+          console.log(`    FI: ${fiSentence.substring(0, 80)}${fiSentence.length > 80 ? '...' : ''}`);
+          console.log(`    EN: ${enSentence.substring(0, 80)}${enSentence.length > 80 ? '...' : ''}`);
+          cards.push({ front: fiSentence, back: enSentence });
         }
+      }
+
+      // Warn about unpaired sentences
+      if (currentSentences.length !== translationSentences.length) {
+        const diff = Math.abs(currentSentences.length - translationSentences.length);
+        console.warn(`⚠️  ${diff} sentence(s) not paired in paragraph ${i + 1}`);
       }
     }
 
+    console.log('\n═══════════════════════════════════════════════════════════');
+    console.log('📊 GENERATION SUMMARY');
+    console.log('═══════════════════════════════════════════════════════════');
+    console.log(`✅ Total cards generated: ${cards.length}`);
+    console.log(`📝 Paragraphs processed: ${maxParagraphs}`);
     if (skippedParagraphs > 0) {
-      console.log(`Skipped ${skippedParagraphs} paragraphs due to alignment issues`);
+      console.log(`⚠️  Paragraphs skipped due to alignment issues: ${skippedParagraphs}`);
     }
+    console.log('═══════════════════════════════════════════════════════════\n');
 
     return cards;
   }

--- a/themes/selkoarchive/static/js/anki-generator.js
+++ b/themes/selkoarchive/static/js/anki-generator.js
@@ -1,0 +1,355 @@
+/**
+ * Anki Card Generator for Selkouutiset Archive
+ * Generates Anki-importable text files from bilingual articles
+ */
+
+class AnkiGenerator {
+  constructor() {
+    this.currentLang = document.documentElement.lang || 'fi';
+    this.otherLang = this.currentLang === 'fi' ? 'en' : 'fi';
+  }
+
+  /**
+   * Get the article content from the current page
+   */
+  getCurrentContent() {
+    const article = document.querySelector('article.prose');
+    if (!article) {
+      throw new Error('Article content not found');
+    }
+    return article;
+  }
+
+  /**
+   * Fetch the translation of the current article
+   */
+  async fetchTranslation() {
+    // Find the translation link
+    const translationLink = document.querySelector(`aside a[hreflang="${this.otherLang}"]`);
+    if (!translationLink) {
+      throw new Error('Translation link not found');
+    }
+
+    const translationUrl = translationLink.href;
+
+    try {
+      const response = await fetch(translationUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch translation: ${response.status}`);
+      }
+
+      const html = await response.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const article = doc.querySelector('article.prose');
+
+      if (!article) {
+        throw new Error('Translation article not found');
+      }
+
+      return article;
+    } catch (error) {
+      console.error('Error fetching translation:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Split content into sentences
+   */
+  splitIntoSentences(text) {
+    // Simple sentence splitting - can be improved for Finnish
+    // Handles common abbreviations
+    const sentences = text
+      .replace(/([.!?])\s+(?=[A-ZÄÖÅ])/g, '$1|')
+      .split('|')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    return sentences;
+  }
+
+  /**
+   * Split content into paragraphs
+   */
+  splitIntoParagraphs(element) {
+    const paragraphs = [];
+    const pElements = element.querySelectorAll('p');
+
+    pElements.forEach(p => {
+      const text = p.textContent.trim();
+      if (text.length > 0) {
+        paragraphs.push(text);
+      }
+    });
+
+    return paragraphs;
+  }
+
+  /**
+   * Split content into sections
+   */
+  splitIntoSections(element) {
+    const sections = [];
+    const children = Array.from(element.children);
+
+    let currentSection = { heading: '', content: [] };
+
+    children.forEach(child => {
+      if (child.tagName.match(/^H[2-6]$/)) {
+        // New section starts
+        if (currentSection.heading || currentSection.content.length > 0) {
+          sections.push(currentSection);
+        }
+        currentSection = { heading: child.textContent.trim(), content: [] };
+      } else if (child.tagName === 'P') {
+        const text = child.textContent.trim();
+        if (text.length > 0) {
+          currentSection.content.push(text);
+        }
+      }
+    });
+
+    // Add the last section
+    if (currentSection.heading || currentSection.content.length > 0) {
+      sections.push(currentSection);
+    }
+
+    return sections;
+  }
+
+  /**
+   * Generate cards at sentence level
+   */
+  async generateSentenceCards() {
+    const currentArticle = this.getCurrentContent();
+    const translationArticle = await this.fetchTranslation();
+
+    const currentParagraphs = this.splitIntoParagraphs(currentArticle);
+    const translationParagraphs = this.splitIntoParagraphs(translationArticle);
+
+    const cards = [];
+
+    // Process each paragraph pair
+    const maxParagraphs = Math.min(currentParagraphs.length, translationParagraphs.length);
+
+    for (let i = 0; i < maxParagraphs; i++) {
+      const currentSentences = this.splitIntoSentences(currentParagraphs[i]);
+      const translationSentences = this.splitIntoSentences(translationParagraphs[i]);
+
+      // Pair sentences - use the minimum count to avoid misalignment
+      const maxSentences = Math.min(currentSentences.length, translationSentences.length);
+
+      for (let j = 0; j < maxSentences; j++) {
+        const front = this.currentLang === 'fi' ? currentSentences[j] : translationSentences[j];
+        const back = this.currentLang === 'fi' ? translationSentences[j] : currentSentences[j];
+
+        if (front && back) {
+          cards.push({ front, back });
+        }
+      }
+    }
+
+    return cards;
+  }
+
+  /**
+   * Generate cards at paragraph level
+   */
+  async generateParagraphCards() {
+    const currentArticle = this.getCurrentContent();
+    const translationArticle = await this.fetchTranslation();
+
+    const currentParagraphs = this.splitIntoParagraphs(currentArticle);
+    const translationParagraphs = this.splitIntoParagraphs(translationArticle);
+
+    const cards = [];
+    const maxParagraphs = Math.min(currentParagraphs.length, translationParagraphs.length);
+
+    for (let i = 0; i < maxParagraphs; i++) {
+      const front = this.currentLang === 'fi' ? currentParagraphs[i] : translationParagraphs[i];
+      const back = this.currentLang === 'fi' ? translationParagraphs[i] : currentParagraphs[i];
+
+      if (front && back) {
+        cards.push({ front, back });
+      }
+    }
+
+    return cards;
+  }
+
+  /**
+   * Generate cards at section level
+   */
+  async generateSectionCards() {
+    const currentArticle = this.getCurrentContent();
+    const translationArticle = await this.fetchTranslation();
+
+    const currentSections = this.splitIntoSections(currentArticle);
+    const translationSections = this.splitIntoSections(translationArticle);
+
+    const cards = [];
+    const maxSections = Math.min(currentSections.length, translationSections.length);
+
+    for (let i = 0; i < maxSections; i++) {
+      const currentContent = currentSections[i].content.join('\n\n');
+      const translationContent = translationSections[i].content.join('\n\n');
+
+      if (currentContent && translationContent) {
+        const front = this.currentLang === 'fi' ? currentContent : translationContent;
+        const back = this.currentLang === 'fi' ? translationContent : currentContent;
+
+        cards.push({ front, back });
+      }
+    }
+
+    return cards;
+  }
+
+  /**
+   * Convert cards to Anki-importable TSV format
+   */
+  cardsToTSV(cards, metadata = {}) {
+    const lines = [];
+
+    // Add metadata as comments
+    lines.push('#separator:tab');
+    lines.push('#html:false');
+    lines.push('#tags column:3');
+    if (metadata.title) {
+      lines.push(`# Source: ${metadata.title}`);
+    }
+    if (metadata.url) {
+      lines.push(`# URL: ${metadata.url}`);
+    }
+    lines.push('');
+
+    // Add cards
+    cards.forEach(card => {
+      const front = card.front.replace(/\t/g, ' ').replace(/\n/g, '<br>');
+      const back = card.back.replace(/\t/g, ' ').replace(/\n/g, '<br>');
+      const tags = metadata.tags || 'selkouutiset';
+
+      lines.push(`${front}\t${back}\t${tags}`);
+    });
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Download content as a file
+   */
+  downloadFile(content, filename) {
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  /**
+   * Generate and download Anki cards
+   */
+  async generate(level) {
+    try {
+      // Show loading indicator
+      const indicator = this.showLoadingIndicator();
+
+      let cards = [];
+
+      switch (level) {
+        case 'sentence':
+          cards = await this.generateSentenceCards();
+          break;
+        case 'paragraph':
+          cards = await this.generateParagraphCards();
+          break;
+        case 'section':
+          cards = await this.generateSectionCards();
+          break;
+        default:
+          throw new Error(`Unknown level: ${level}`);
+      }
+
+      if (cards.length === 0) {
+        alert('No cards generated. The article might not have a translation or the content structure is incompatible.');
+        this.hideLoadingIndicator(indicator);
+        return;
+      }
+
+      // Get metadata
+      const title = document.title || 'Selkouutiset Article';
+      const url = window.location.href;
+      const date = new Date().toISOString().split('T')[0];
+
+      const metadata = {
+        title: title,
+        url: url,
+        tags: `selkouutiset ${this.currentLang}-${this.otherLang} ${level} ${date}`
+      };
+
+      // Convert to TSV
+      const tsv = this.cardsToTSV(cards, metadata);
+
+      // Generate filename
+      const safeTitle = title.replace(/[^a-z0-9]/gi, '_').substring(0, 50);
+      const filename = `anki_${safeTitle}_${level}_${date}.txt`;
+
+      // Download
+      this.downloadFile(tsv, filename);
+
+      this.hideLoadingIndicator(indicator);
+
+      // Show success message
+      alert(`Generated ${cards.length} cards!\n\nTo import into Anki:\n1. Open Anki\n2. File → Import\n3. Select the downloaded file\n4. Set "Fields separated by: Tab"\n5. Set "Allow HTML in fields"\n6. Click Import`);
+
+    } catch (error) {
+      console.error('Error generating Anki cards:', error);
+      alert(`Error generating Anki cards: ${error.message}`);
+    }
+  }
+
+  /**
+   * Show a loading indicator
+   */
+  showLoadingIndicator() {
+    const indicator = document.createElement('div');
+    indicator.id = 'anki-loading';
+    indicator.style.cssText = `
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(0, 0, 0, 0.8);
+      color: white;
+      padding: 20px 40px;
+      border-radius: 8px;
+      font-size: 16px;
+      z-index: 10000;
+    `;
+    indicator.textContent = 'Generating Anki cards...';
+    document.body.appendChild(indicator);
+    return indicator;
+  }
+
+  /**
+   * Hide the loading indicator
+   */
+  hideLoadingIndicator(indicator) {
+    if (indicator && indicator.parentNode) {
+      indicator.parentNode.removeChild(indicator);
+    }
+  }
+}
+
+// Initialize global instance
+window.ankiGenerator = new AnkiGenerator();
+
+// Global function for easy access from HTML
+window.generateAnkiCards = function(level) {
+  window.ankiGenerator.generate(level);
+};


### PR DESCRIPTION
This plan outlines how to add three hyperlinks next to the language selectors
([fi] and [en]) that allow users to generate Anki flashcards from article
content at different granularity levels:
- Sentence level
- Paragraph level
- Whole sections level

The plan covers:
- Current implementation analysis of language selectors
- Multiple implementation approaches (client-side vs server-side)
- UI/UX design considerations
- Content parsing requirements for bilingual content
- Anki deck format specifications
- Testing strategy
- Implementation roadmap with MVP and future enhancements
- Open questions and recommendations

Recommended approach: Start with client-side JavaScript implementation for MVP,
focusing on sentence-level generation first, then iterate based on feedback.